### PR TITLE
Add support for dependency injection (via Microsoft.Extensions.DependencyInjection / Microsoft.Extensions.Http)

### DIFF
--- a/HTTPlease.sln
+++ b/HTTPlease.sln
@@ -1,6 +1,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.27130.2024
+# Visual Studio Version 17
+VisualStudioVersion = 17.8.34330.188
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{E084508E-FBEB-4A72-9C38-C34E270E8C2B}"
 	ProjectSection(SolutionItems) = preProject
@@ -36,6 +36,8 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "HTTPlease.Diagnostics", "src\HTTPlease.Diagnostics\HTTPlease.Diagnostics.csproj", "{5355EEF6-2E9D-452F-A3C8-4C9F38D39EF1}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "HTTPlease.Diagnostics.Tests", "test\HTTPlease.Diagnostics.Tests\HTTPlease.Diagnostics.Tests.csproj", "{7252EB2F-2373-40CD-A7B6-B24919B974AF}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HTTPlease.Extensions.DependencyInjection", "src\HTTPlease.Extensions.DependencyInjection\HTTPlease.Extensions.DependencyInjection.csproj", "{12FC2297-115D-4274-AD6E-D46DC7A5A0F4}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -203,6 +205,18 @@ Global
 		{7252EB2F-2373-40CD-A7B6-B24919B974AF}.Release|x64.Build.0 = Release|Any CPU
 		{7252EB2F-2373-40CD-A7B6-B24919B974AF}.Release|x86.ActiveCfg = Release|Any CPU
 		{7252EB2F-2373-40CD-A7B6-B24919B974AF}.Release|x86.Build.0 = Release|Any CPU
+		{12FC2297-115D-4274-AD6E-D46DC7A5A0F4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{12FC2297-115D-4274-AD6E-D46DC7A5A0F4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{12FC2297-115D-4274-AD6E-D46DC7A5A0F4}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{12FC2297-115D-4274-AD6E-D46DC7A5A0F4}.Debug|x64.Build.0 = Debug|Any CPU
+		{12FC2297-115D-4274-AD6E-D46DC7A5A0F4}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{12FC2297-115D-4274-AD6E-D46DC7A5A0F4}.Debug|x86.Build.0 = Debug|Any CPU
+		{12FC2297-115D-4274-AD6E-D46DC7A5A0F4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{12FC2297-115D-4274-AD6E-D46DC7A5A0F4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{12FC2297-115D-4274-AD6E-D46DC7A5A0F4}.Release|x64.ActiveCfg = Release|Any CPU
+		{12FC2297-115D-4274-AD6E-D46DC7A5A0F4}.Release|x64.Build.0 = Release|Any CPU
+		{12FC2297-115D-4274-AD6E-D46DC7A5A0F4}.Release|x86.ActiveCfg = Release|Any CPU
+		{12FC2297-115D-4274-AD6E-D46DC7A5A0F4}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -221,6 +235,7 @@ Global
 		{B7DE2327-D1E3-4F30-8603-C7277A304A73} = {244D5A84-F66C-4628-A33A-5FBA3E9895B4}
 		{5355EEF6-2E9D-452F-A3C8-4C9F38D39EF1} = {244D5A84-F66C-4628-A33A-5FBA3E9895B4}
 		{7252EB2F-2373-40CD-A7B6-B24919B974AF} = {D91C25AB-6BDD-485E-8375-B638972DC8EF}
+		{12FC2297-115D-4274-AD6E-D46DC7A5A0F4} = {244D5A84-F66C-4628-A33A-5FBA3E9895B4}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {9A554FA4-21BC-4666-8041-2FB39C103BAB}

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "6.0.203",
-    "rollForward": "latestFeature"
+    "version": "8.0.100",
+    "rollForward": "minor"
   }
 }

--- a/src/Common.props
+++ b/src/Common.props
@@ -3,6 +3,8 @@
     <PropertyGroup>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
 				<LangVersion>latest</LangVersion>
+
+			<NoWarn>$(NoWarn);NU1903</NoWarn>
     </PropertyGroup>
 
     <!-- Common package properties -->

--- a/src/HTTPlease.Core/ClientBuilder.cs
+++ b/src/HTTPlease.Core/ClientBuilder.cs
@@ -225,6 +225,20 @@ namespace HTTPlease
 		}
 
 		/// <summary>
+		///		Create a copy of the <see cref="ClientBuilder"/>, but with the default message pipeline terminus.
+		/// </summary>
+		/// <returns>
+		/// 	The configured <see cref="ClientBuilder"/>.
+		/// </returns>
+		public ClientBuilder WithDefaultMessagePipelineTerminus()
+		{
+			return new ClientBuilder(this)
+			{
+				_pipelineTerminusConfigurators = DefaultPipelineTerminusConfigurators
+			};
+		}
+
+		/// <summary>
 		///		Create a copy of the <see cref="ClientBuilder"/>, adding an HTTP message-handler factory to the end of the pipeline.
 		/// </summary>
 		/// <typeparam name="THandler">

--- a/src/HTTPlease.Core/ClientBuilder.cs
+++ b/src/HTTPlease.Core/ClientBuilder.cs
@@ -25,6 +25,11 @@ namespace HTTPlease
 		static readonly Func<HttpMessageHandler, HttpMessageHandler> DefaultMessagePipelineTerminus = existingHandler => new HttpClientHandler();
 
 		/// <summary>
+		///		The default list of configurator delegates for message-pipeline terminus handlers.
+		/// </summary>
+		static readonly ImmutableList<Func<HttpMessageHandler, HttpMessageHandler>> DefaultPipelineTerminusConfigurators = ImmutableList.Create(DefaultMessagePipelineTerminus);
+
+		/// <summary>
 		///		Factory delegates used to produce the HTTP message handlers that comprise client pipelines.
 		/// </summary>
 		ImmutableList<Func<DelegatingHandler>> _handlerFactories = ImmutableList<Func<DelegatingHandler>>.Empty;
@@ -37,7 +42,7 @@ namespace HTTPlease
 		/// 
         /// 	Can be overridden by the value passed to CreateClient.
         /// </remarks>
-		ImmutableList<Func<HttpMessageHandler, HttpMessageHandler>> _pipelineTerminusConfigurators = ImmutableList.Create(DefaultMessagePipelineTerminus);
+		ImmutableList<Func<HttpMessageHandler, HttpMessageHandler>> _pipelineTerminusConfigurators = DefaultPipelineTerminusConfigurators;
 
 		/// <summary>
 		///		Create a new HTTP client builder.
@@ -60,6 +65,11 @@ namespace HTTPlease
 			_handlerFactories = copyFrom._handlerFactories;
 			_pipelineTerminusConfigurators = copyFrom._pipelineTerminusConfigurators;
 		}
+
+		/// <summary>
+		///		Does the <see cref="ClientBuilder"/> specify a custom handler for the terminus of the message-hander pipeline.
+		/// </summary>
+		public bool HasCustomPipelineTerminus => _pipelineTerminusConfigurators != DefaultPipelineTerminusConfigurators;
 
 		/// <summary>
 		///		Create an <see cref="HttpClient"/> using the configured message-handler pipeline.

--- a/src/HTTPlease.Core/ClientBuilderOfTContext.cs
+++ b/src/HTTPlease.Core/ClientBuilderOfTContext.cs
@@ -15,7 +15,7 @@ namespace HTTPlease
     ///		Builds <see cref="HttpClient"/>s with pipelines of <see cref="DelegatingHandler">HTTP message handler</see>s.
     /// </summary>
     /// <remarks>
-	///		Unlike <see cref="ClientBuilder"/>, <see cref="ClientBuilder{TContext}"/> provides a <typeparamref name="TContext"/> that can be passed to its configuration delegates.
+	///		Unlike <see cref="ClientBuilder{TContext}"/>, <see cref="ClientBuilder{TContext}"/> provides a <typeparamref name="TContext"/> that can be passed to its configuration delegates.
 	///		
     ///		Be aware that, if you return singleton instances of message handlers from factory delegates, those handlers will be disposed if the factory encounters any exception while creating a client.
     /// </remarks>
@@ -129,7 +129,7 @@ namespace HTTPlease
 		///		The <typeparamref name="TContext"/> that contains contextual information used when creating the handler.
 		/// </param>
 		/// <param name="initialPipelineTerminus">
-		///		The initial <see cref="HttpMessageHandler"/> to use as the pipeline terminus (this is optional, and may ignored by the <see cref="ClientBuilder"/>'s configuration).
+		///		The initial <see cref="HttpMessageHandler"/> to use as the pipeline terminus (this is optional, and may ignored by the <see cref="ClientBuilder{TContext}"/>'s configuration).
 		/// </param>
 		/// <returns>
 		/// 	The configured <see cref="HttpMessageHandler"/>.
@@ -192,7 +192,7 @@ namespace HTTPlease
 		}
 
 		/// <summary>
-        ///		Create a copy of the <see cref="ClientBuilder"/>, but with the specified configuration for its message pipeline terminus.
+        ///		Create a copy of the <see cref="ClientBuilder{TContext}"/>, but with the specified configuration for its message pipeline terminus.
         /// </summary>
         /// <param name="pipelineTerminusConfigurator">
 		/// 	A delegate that creates the <see cref="HttpMessageHandler"/> for each <see cref="HttpClient"/> that will form its message pipeline terminus.
@@ -200,7 +200,7 @@ namespace HTTPlease
 		/// 	If <c>null</c>, the default message handler pipeline terminus will be used.
 		/// </param>
         /// <returns>
-		/// 	The configured <see cref="ClientBuilder"/>.
+		/// 	The configured <see cref="ClientBuilder{TContext}"/>.
 		/// </returns>
 		public ClientBuilder<TContext> WithMessagePipelineTerminus(Func<HttpMessageHandler, TContext, HttpMessageHandler> pipelineTerminusConfigurator)
 		{
@@ -213,7 +213,7 @@ namespace HTTPlease
 		}
 
 		/// <summary>
-        ///		Create a copy of the <see cref="ClientBuilder"/>, but with the specified message pipeline terminus.
+        ///		Create a copy of the <see cref="ClientBuilder{TContext}"/>, but with the specified message pipeline terminus.
         /// </summary>
         /// <param name="pipelineTerminusFactory">
 		/// 	A delegate that creates the <see cref="HttpMessageHandler"/> for each <see cref="HttpClient"/> that will form its message pipeline terminus.
@@ -221,7 +221,7 @@ namespace HTTPlease
 		/// 	If <c>null</c>, the default message handler pipeline terminus will be used.
 		/// </param>
         /// <returns>
-		/// 	The configured <see cref="ClientBuilder"/>.
+		/// 	The configured <see cref="ClientBuilder{TContext}"/>.
 		/// </returns>
 		public ClientBuilder<TContext> WithMessagePipelineTerminus(Func<TContext, HttpMessageHandler> pipelineTerminusFactory)
 		{
@@ -236,7 +236,21 @@ namespace HTTPlease
 		}
 
 		/// <summary>
-		///		Create a copy of the <see cref="ClientBuilder"/>, adding an HTTP message-handler factory to the end of the pipeline.
+		///		Create a copy of the <see cref="ClientBuilder{TContext}"/>, but with the default message pipeline terminus.
+		/// </summary>
+		/// <returns>
+		/// 	The configured <see cref="ClientBuilder{TContext}"/>.
+		/// </returns>
+		public ClientBuilder<TContext> WithDefaultMessagePipelineTerminus()
+		{
+			return new ClientBuilder<TContext>(this)
+			{
+				_pipelineTerminusConfigurators = DefaultPipelineTerminusConfigurators
+			};
+		}
+
+		/// <summary>
+		///		Create a copy of the <see cref="ClientBuilder{TContext}"/>, adding an HTTP message-handler factory to the end of the pipeline.
 		/// </summary>
 		/// <typeparam name="THandler">
 		///		The handler type.
@@ -245,7 +259,7 @@ namespace HTTPlease
 		///		The message-handler factory.
 		/// </param>
 		/// <returns>
-		///		The <see cref="ClientBuilder"/> (enables method-chaining).
+		///		The <see cref="ClientBuilder{TContext}"/> (enables method-chaining).
 		/// </returns>
 		/// <remarks>
 		///		<typeparamref name="THandler"/> cannot be the <see cref="DelegatingHandler"/> base class.
@@ -276,7 +290,7 @@ namespace HTTPlease
 		}
 
 		/// <summary>
-		///		Create a copy of the <see cref="ClientBuilder"/>, inserting an HTTP message-handler factory to the pipeline before the factory that produces handlers of the specified type.
+		///		Create a copy of the <see cref="ClientBuilder{TContext}"/>, inserting an HTTP message-handler factory to the pipeline before the factory that produces handlers of the specified type.
 		/// </summary>
 		/// <typeparam name="THandler">
 		///		The handler type.
@@ -293,7 +307,7 @@ namespace HTTPlease
 		///		Default is <c>false</c>.
 		/// </param>
 		/// <returns>
-		///		The <see cref="ClientBuilder"/> (enables method-chaining).
+		///		The <see cref="ClientBuilder{TContext}"/> (enables method-chaining).
 		/// </returns>
 		/// <remarks>
 		///		<typeparamref name="THandler"/> and <typeparamref name="TBeforeHandler"/> cannot be the <see cref="DelegatingHandler"/> base class.
@@ -352,7 +366,7 @@ namespace HTTPlease
 		}
 
 		/// <summary>
-		///		Create a copy of the <see cref="ClientBuilder"/>, inserting an HTTP message-handler factory to the pipeline after the factory that produces handlers of the specified type.
+		///		Create a copy of the <see cref="ClientBuilder{TContext}"/>, inserting an HTTP message-handler factory to the pipeline after the factory that produces handlers of the specified type.
 		/// </summary>
 		/// <typeparam name="THandler">
 		///		The handler type.
@@ -369,7 +383,7 @@ namespace HTTPlease
 		///		Default is <c>false</c>.
 		/// </param>
 		/// <returns>
-		///		The <see cref="ClientBuilder"/> (enables method-chaining).
+		///		The <see cref="ClientBuilder{TContext}"/> (enables method-chaining).
 		/// </returns>
 		/// <remarks>
 		///		<typeparamref name="THandler"/> and <typeparamref name="TAfterHandler"/> cannot be the <see cref="DelegatingHandler"/> base class.

--- a/src/HTTPlease.Extensions.DependencyInjection/HTTPlease.Extensions.DependencyInjection.csproj
+++ b/src/HTTPlease.Extensions.DependencyInjection/HTTPlease.Extensions.DependencyInjection.csproj
@@ -1,0 +1,29 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    
+		<AssemblyName>HTTPlease.Extensions.DependencyInjection</AssemblyName>
+    
+    <PackageId>HTTPlease.Extensions.DependencyInjection</PackageId>
+    <PackageTags>HTTPlease;DependencyInjection</PackageTags>
+  </PropertyGroup>
+	
+	<Import Project="../Common.props"/>
+
+  <ItemGroup>
+    <ProjectReference Include="..\HTTPlease.Core\HTTPlease.Core.csproj" />
+    <ProjectReference Include="..\HTTPlease.Diagnostics\HTTPlease.Diagnostics.csproj" />
+    <ProjectReference Include="..\HTTPlease.Formatters.Json\HTTPlease.Formatters.Json.csproj" />
+    <ProjectReference Include="..\HTTPlease.Formatters\HTTPlease.Formatters.csproj" />
+    <ProjectReference Include="..\HTTPlease.Security\HTTPlease.Security.csproj" />
+  </ItemGroup>
+
+
+	<ItemGroup>
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
+    <PackageReference Include="System.Collections.Immutable" Version="1.2.0" />
+	</ItemGroup>
+</Project>

--- a/src/HTTPlease.Extensions.DependencyInjection/HTTPleaseDependencyInjectionExtensions.cs
+++ b/src/HTTPlease.Extensions.DependencyInjection/HTTPleaseDependencyInjectionExtensions.cs
@@ -12,53 +12,44 @@ namespace HTTPlease
 	public static class HTTPleaseDependencyInjectionExtensions
 	{
 		/// <summary>
-		///		Configure an <see cref="IHttpClientBuilder"/> to use an HTTPlease <see cref="ClientBuilder"/> for handler configuration.
+		///		Register a named <see cref="HttpClient"/> (via <see cref="IHttpClientFactory"/>) using the configuration from an HTTPlease <see cref="ClientBuilder"/>.
 		/// </summary>
-		/// <param name="client">
-		///		The <see cref="IHttpClientBuilder"/> to configure.
+		/// <param name="services">
+		///		The <see cref="IServiceCollection"/> to configure.
+		/// </param>
+		/// <param name="name">
+		///		The name of the <see cref="HttpClient"/> configuration to register.
 		/// </param>
 		/// <param name="httplease">
 		///		The HTTPlease <see cref="ClientBuilder"/> to use for handler configuration.
 		/// </param>
-		/// <param name="includePipelineTerminus">
-		///		Also use the <see cref="ClientBuilder"/> to create the handler pipeline?
-		///		
-		///		NOTE: under normal circumstances, this probably is not what you want (Microsoft.Extensions.Http usually provides a pipeline terminus that takes are of connection pooling, etc).
-		/// </param>
 		/// <returns>
-		///		The configured <see cref="IHttpClientBuilder"/>.
+		///		An <see cref="IHttpClientBuilder"/> representing the <see cref="HttpClient"/> configuration (enables further customisation).
 		/// </returns>
-		public static IHttpClientBuilder UseHTTPlease(this IHttpClientBuilder client, ClientBuilder httplease, bool includePipelineTerminus = false)
+		public static IHttpClientBuilder AddHttpClient(this IServiceCollection services, string name, ClientBuilder httplease)
 		{
-			if (client == null)
-				throw new ArgumentNullException(nameof(client));
+			if (services == null)
+				throw new ArgumentNullException(nameof(services));
+
+			if (String.IsNullOrWhiteSpace(name))
+				throw new ArgumentException($"Argument cannot be null, empty, or entirely composed of whitespace: {nameof(name)}.", nameof(name));
 
 			if (httplease == null)
 				throw new ArgumentNullException(nameof(httplease));
 
-			if (includePipelineTerminus)
-			{
-				client.ConfigurePrimaryHttpMessageHandler(
-					() => httplease.BuildPipelineTerminus()
-				);
-			}
-			
-			client.ConfigureAdditionalHttpMessageHandlers((handlers, serviceProvider) =>
-			{
-				List<DelegatingHandler> httpleaseHandlers = httplease.CreatePipelineHandlers();
-				
-				foreach (DelegatingHandler httpleaseHandler in httpleaseHandlers)
-					handlers.Add(httpleaseHandler);
-			});
+			IHttpClientBuilder client = services.AddHttpClient(name);
 
-			return client;
+			return client.Configure(httplease);
 		}
 
 		/// <summary>
-		///		Configure an <see cref="IHttpClientBuilder"/> to use an HTTPlease <see cref="ClientBuilder{TContext}"/> for handler configuration.
+		///		Register a named <see cref="HttpClient"/> (via <see cref="IHttpClientFactory"/>) using the configuration from an HTTPlease <see cref="ClientBuilder"/>.
 		/// </summary>
-		/// <param name="client">
-		///		The <see cref="IHttpClientBuilder"/> to configure.
+		/// <param name="services">
+		///		The <see cref="IServiceCollection"/> to configure.
+		/// </param>
+		/// <param name="name">
+		///		The name of the <see cref="HttpClient"/> configuration to register.
 		/// </param>
 		/// <param name="httplease">
 		///		The HTTPlease <see cref="ClientBuilder{TContext}"/> to use for handler configuration.
@@ -67,15 +58,38 @@ namespace HTTPlease
 		///			 Configuration delegates will have access to a scoped <see cref="IServiceProvider"/>; see <see href="https://learn.microsoft.com/en-us/dotnet/core/extensions/httpclient-factory#message-handler-scopes-in-ihttpclientfactory"/> for further information.
 		///		</para>
 		/// </param>
-		/// <param name="includePipelineTerminus">
-		///		Also use the <see cref="ClientBuilder"/> to create the handler pipeline?
-		///		
-		///		NOTE: under normal circumstances, this probably is not what you want (Microsoft.Extensions.Http usually provides a pipeline terminus that takes are of connection pooling, etc).
+		/// <returns>
+		///		An <see cref="IHttpClientBuilder"/> representing the <see cref="HttpClient"/> configuration (enables further customisation).
+		/// </returns>
+		public static IHttpClientBuilder AddHttpClient(this IServiceCollection services, string name, ClientBuilder<IServiceProvider> httplease)
+		{
+			if (services == null)
+				throw new ArgumentNullException(nameof(services));
+
+			if (String.IsNullOrWhiteSpace(name))
+				throw new ArgumentException($"Argument cannot be null, empty, or entirely composed of whitespace: {nameof(name)}.", nameof(name));
+
+			if (httplease == null)
+				throw new ArgumentNullException(nameof(httplease));
+
+			IHttpClientBuilder client = services.AddHttpClient(name);
+
+			return client.Configure(httplease);
+		}
+
+		/// <summary>
+		///		Configure an <see cref="HttpClient"/> using an HTTPlease client-builder.
+		/// </summary>
+		/// <param name="client">
+		///		An <see cref="IHttpClientBuilder"/> representing the <see cref="HttpClient"/> configuration.
+		/// </param>
+		/// <param name="httplease">
+		///		The HTTPlease <see cref="ClientBuilder"/> used to configure the <see cref="HttpClient"/>.
 		/// </param>
 		/// <returns>
 		///		The configured <see cref="IHttpClientBuilder"/>.
 		/// </returns>
-		public static IHttpClientBuilder UseHTTPlease(this IHttpClientBuilder client, ClientBuilder<IServiceProvider> httplease, bool includePipelineTerminus = false)
+		static IHttpClientBuilder Configure(this IHttpClientBuilder client, ClientBuilder httplease)
 		{
 			if (client == null)
 				throw new ArgumentNullException(nameof(client));
@@ -83,7 +97,45 @@ namespace HTTPlease
 			if (httplease == null)
 				throw new ArgumentNullException(nameof(httplease));
 
-			if (includePipelineTerminus)
+			if (httplease.HasCustomPipelineTerminus)
+			{
+				client.ConfigurePrimaryHttpMessageHandler(
+					() => httplease.BuildPipelineTerminus()
+				);
+			}
+
+			client.ConfigureAdditionalHttpMessageHandlers((handlers, serviceProvider) =>
+			{
+				List<DelegatingHandler> httpleaseHandlers = httplease.CreatePipelineHandlers();
+
+				foreach (DelegatingHandler httpleaseHandler in httpleaseHandlers)
+					handlers.Add(httpleaseHandler);
+			});
+
+			return client;
+		}
+
+		/// <summary>
+		///		Configure an <see cref="HttpClient"/> using an HTTPlease client-builder.
+		/// </summary>
+		/// <param name="client">
+		///		An <see cref="IHttpClientBuilder"/> representing the <see cref="HttpClient"/> configuration.
+		/// </param>
+		/// <param name="httplease">
+		///		The HTTPlease <see cref="ClientBuilder{TContext}"/> used to configure the <see cref="HttpClient"/>.
+		/// </param>
+		/// <returns>
+		///		The configured <see cref="IHttpClientBuilder"/>.
+		/// </returns>
+		static IHttpClientBuilder Configure(this IHttpClientBuilder client, ClientBuilder<IServiceProvider> httplease)
+		{
+			if (client == null)
+				throw new ArgumentNullException(nameof(client));
+
+			if (httplease == null)
+				throw new ArgumentNullException(nameof(httplease));
+
+			if (httplease.HasCustomPipelineTerminus)
 			{
 				client.ConfigurePrimaryHttpMessageHandler(
 					serviceProvider => httplease.BuildPipelineTerminus(serviceProvider)

--- a/src/HTTPlease.Extensions.DependencyInjection/HTTPleaseDependencyInjectionExtensions.cs
+++ b/src/HTTPlease.Extensions.DependencyInjection/HTTPleaseDependencyInjectionExtensions.cs
@@ -1,0 +1,104 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+
+// Root namespace, for discoverability.
+namespace HTTPlease
+{
+	/// <summary>
+	///		Extension methods for registering and resolving HTTPlease components for dependency injection.
+	/// </summary>
+	public static class HTTPleaseDependencyInjectionExtensions
+	{
+		/// <summary>
+		///		Configure an <see cref="IHttpClientBuilder"/> to use an HTTPlease <see cref="ClientBuilder"/> for handler configuration.
+		/// </summary>
+		/// <param name="client">
+		///		The <see cref="IHttpClientBuilder"/> to configure.
+		/// </param>
+		/// <param name="httplease">
+		///		The HTTPlease <see cref="ClientBuilder"/> to use for handler configuration.
+		/// </param>
+		/// <param name="includePipelineTerminus">
+		///		Also use the <see cref="ClientBuilder"/> to create the handler pipeline?
+		///		
+		///		NOTE: under normal circumstances, this probably is not what you want (Microsoft.Extensions.Http usually provides a pipeline terminus that takes are of connection pooling, etc).
+		/// </param>
+		/// <returns>
+		///		The configured <see cref="IHttpClientBuilder"/>.
+		/// </returns>
+		public static IHttpClientBuilder UseHTTPlease(this IHttpClientBuilder client, ClientBuilder httplease, bool includePipelineTerminus = false)
+		{
+			if (client == null)
+				throw new ArgumentNullException(nameof(client));
+
+			if (httplease == null)
+				throw new ArgumentNullException(nameof(httplease));
+
+			if (includePipelineTerminus)
+			{
+				client.ConfigurePrimaryHttpMessageHandler(
+					() => httplease.BuildPipelineTerminus()
+				);
+			}
+			
+			client.ConfigureAdditionalHttpMessageHandlers((handlers, serviceProvider) =>
+			{
+				List<DelegatingHandler> httpleaseHandlers = httplease.CreatePipelineHandlers();
+				
+				foreach (DelegatingHandler httpleaseHandler in httpleaseHandlers)
+					handlers.Add(httpleaseHandler);
+			});
+
+			return client;
+		}
+
+		/// <summary>
+		///		Configure an <see cref="IHttpClientBuilder"/> to use an HTTPlease <see cref="ClientBuilder{TContext}"/> for handler configuration.
+		/// </summary>
+		/// <param name="client">
+		///		The <see cref="IHttpClientBuilder"/> to configure.
+		/// </param>
+		/// <param name="httplease">
+		///		The HTTPlease <see cref="ClientBuilder{TContext}"/> to use for handler configuration.
+		///		
+		///		<para>
+		///			 Configuration delegates will have access to a scoped <see cref="IServiceProvider"/>; see <see href="https://learn.microsoft.com/en-us/dotnet/core/extensions/httpclient-factory#message-handler-scopes-in-ihttpclientfactory"/> for further information.
+		///		</para>
+		/// </param>
+		/// <param name="includePipelineTerminus">
+		///		Also use the <see cref="ClientBuilder"/> to create the handler pipeline?
+		///		
+		///		NOTE: under normal circumstances, this probably is not what you want (Microsoft.Extensions.Http usually provides a pipeline terminus that takes are of connection pooling, etc).
+		/// </param>
+		/// <returns>
+		///		The configured <see cref="IHttpClientBuilder"/>.
+		/// </returns>
+		public static IHttpClientBuilder UseHTTPlease(this IHttpClientBuilder client, ClientBuilder<IServiceProvider> httplease, bool includePipelineTerminus = false)
+		{
+			if (client == null)
+				throw new ArgumentNullException(nameof(client));
+
+			if (httplease == null)
+				throw new ArgumentNullException(nameof(httplease));
+
+			if (includePipelineTerminus)
+			{
+				client.ConfigurePrimaryHttpMessageHandler(
+					serviceProvider => httplease.BuildPipelineTerminus(serviceProvider)
+				);
+			}
+
+			client.ConfigureAdditionalHttpMessageHandlers((handlers, serviceProvider) =>
+			{
+				List<DelegatingHandler> httpleaseHandlers = httplease.CreatePipelineHandlers(serviceProvider);
+
+				foreach (DelegatingHandler httpleaseHandler in httpleaseHandlers)
+					handlers.Add(httpleaseHandler);
+			});
+
+			return client;
+		}
+	}
+}

--- a/test/HTTPlease.Core.Tests/ClientBuilderTests.cs
+++ b/test/HTTPlease.Core.Tests/ClientBuilderTests.cs
@@ -1,0 +1,118 @@
+﻿using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace HTTPlease.Core.Tests
+{
+	using Testability;
+	using Testability.Mocks;
+	using Xunit.Sdk;
+
+	/// <summary>
+	///		Unit-tests for <see cref="ClientBuilder"/>.
+	/// </summary>
+	public class ClientBuilderTests
+	{
+		/// <summary>
+		///		The base URI used for requests in <see cref="ClientBuilder"/> tests.
+		/// </summary>
+		static readonly Uri BaseUri = new Uri("http://localhost");
+
+		/// <summary>
+		///		The default path used for requests in <see cref="ClientBuilder"/> tests.
+		/// </summary>
+		static readonly string TestRequestPath = "/foo/bar";
+
+		/// <summary>
+		///		The default URI used for requests in <see cref="ClientBuilder"/> tests.
+		/// </summary>
+		static readonly Uri TestRequestUri = new Uri(BaseUri, TestRequestPath);
+
+		/// <summary>
+		///		The default request used for <see cref="ClientBuilder"/> tests.
+		/// </summary>
+		static readonly HttpRequest TestRequest = HttpRequest.Create(TestRequestPath);
+
+		/// <summary>
+		///		Verify that a <see cref="ClientBuilder"/>, configured with the default message pipeline terminus, can build an <see cref="HttpClient"/> with a custom message pipeline terminus.
+		/// </summary>
+		/// <returns>
+		///		A <see cref="Task"/> representing asynchronous test execution.
+		/// </returns>
+		[Fact]
+		public async Task BuilderWithDefaultTerminus_Can_Build_Client_WithCustomTerminus()
+		{
+			using MockMessageHandler testHandler = TestHandlers.RespondWith(request =>
+			{
+				MessageAssert.HasRequestUri(request, TestRequestUri);
+
+				return request.CreateResponse(HttpStatusCode.Ambiguous);
+			});
+
+			ClientBuilder builder = new ClientBuilder();
+
+			using HttpClient client = builder.CreateClient(BaseUri, messagePipelineTerminus: testHandler);
+			using HttpResponseMessage response = await client.GetAsync(TestRequest);
+
+			Assert.Equal(HttpStatusCode.Ambiguous, response.StatusCode);
+		}
+
+		/// <summary>
+		///		Verify that a <see cref="ClientBuilder"/>, configured with a custom message pipeline terminus, can build an <see cref="HttpClient"/> with that message pipeline terminus.
+		/// </summary>
+		/// <returns>
+		///		A <see cref="Task"/> representing asynchronous test execution.
+		/// </returns>
+		[Fact]
+		public async Task BuilderWithCustomTerminus_Can_Build_Client()
+		{
+			using MockMessageHandler testHandler = TestHandlers.RespondWith(request =>
+			{
+				MessageAssert.HasRequestUri(request, TestRequestUri);
+
+				return request.CreateResponse(HttpStatusCode.Ambiguous);
+			});
+
+			ClientBuilder builder = new ClientBuilder().WithMessagePipelineTerminus(() => testHandler);
+
+			using HttpClient client = builder.CreateClient(BaseUri);
+			using HttpResponseMessage response = await client.GetAsync(TestRequest);
+
+			Assert.Equal(HttpStatusCode.Ambiguous, response.StatusCode);
+		}
+
+		/// <summary>
+		///		Verify that a <see cref="ClientBuilder"/>, configured with a custom message pipeline terminus, can build an <see cref="HttpClient"/> with a different message pipeline terminus.
+		/// </summary>
+		/// <returns>
+		///		A <see cref="Task"/> representing asynchronous test execution.
+		/// </returns>
+		[Fact]
+		public async Task BuilderWithCustomTerminus_Can_Build_Client_WithCustomTerminus()
+		{
+			using MockMessageHandler testHandler1 = TestHandlers.RespondWith(request =>
+			{
+				throw new AssertActualExpectedException(
+					expected: "testHandler2",
+					actual: "testHandler1",
+					userMessage: "Client was created with the wrong message pipeline terminus."
+				);
+			});
+			using MockMessageHandler testHandler2 = TestHandlers.RespondWith(request =>
+			{
+				MessageAssert.HasRequestUri(request, TestRequestUri);
+
+				return request.CreateResponse(HttpStatusCode.SeeOther);
+			});
+
+			ClientBuilder builder = new ClientBuilder().WithMessagePipelineTerminus(() => testHandler1);
+
+			using HttpClient client = builder.CreateClient(BaseUri, messagePipelineTerminus: testHandler2);
+			using HttpResponseMessage response = await client.GetAsync(TestRequest);
+
+			Assert.Equal(HttpStatusCode.SeeOther, response.StatusCode);
+		}
+	}
+}

--- a/test/HTTPlease.Core.Tests/TypedClientBuilderTests.cs
+++ b/test/HTTPlease.Core.Tests/TypedClientBuilderTests.cs
@@ -1,0 +1,148 @@
+﻿using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Sdk;
+
+namespace HTTPlease.Core.Tests
+{
+	using Testability;
+	using Testability.Mocks;
+
+	/// <summary>
+	///		Unit-tests for <see cref="ClientBuilder{TContext}"/>.
+	/// </summary>
+	public class TypedClientBuilderTests
+	{
+		/// <summary>
+		///		The base URI used for requests in <see cref="ClientBuilder{TContext}"/> tests.
+		/// </summary>
+		static readonly Uri BaseUri = new Uri("http://localhost");
+
+		/// <summary>
+		///		The default path used for requests in <see cref="ClientBuilder{TContext}"/> tests.
+		/// </summary>
+		static readonly string TestRequestPath = "/foo/bar";
+
+		/// <summary>
+		///		The default URI used for requests in <see cref="ClientBuilder{TContext}"/> tests.
+		/// </summary>
+		static readonly Uri TestRequestUri = new Uri(BaseUri, TestRequestPath);
+
+		/// <summary>
+		///		The default request used for <see cref="ClientBuilder{TContext}"/> tests.
+		/// </summary>
+		static readonly HttpRequest TestRequest = HttpRequest.Create(TestRequestPath);
+
+		/// <summary>
+		///		An <see cref="Object"/> used as the context for handler creation.
+		/// </summary>
+		readonly TestBuilderContext _testBuilderContext = new TestBuilderContext();
+
+		/// <summary>
+		///		Verify that a <see cref="ClientBuilder{TContext}"/>, configured with the default message pipeline terminus, can build an <see cref="HttpClient"/> with a custom message pipeline terminus.
+		/// </summary>
+		/// <returns>
+		///		A <see cref="Task"/> representing asynchronous test execution.
+		/// </returns>
+		[Fact]
+		public async Task BuilderWithDefaultTerminus_Can_Build_Client_WithCustomTerminus()
+		{
+			using MockMessageHandler testHandler = TestHandlers.RespondWith(request =>
+			{
+				MessageAssert.HasRequestUri(request, TestRequestUri);
+
+				return request.CreateResponse(HttpStatusCode.Ambiguous);
+			});
+
+			ClientBuilder<TestBuilderContext> builder = new ClientBuilder<TestBuilderContext>();
+
+			using HttpClient client = builder.CreateClient(_testBuilderContext, BaseUri, messagePipelineTerminus: testHandler);
+			using HttpResponseMessage response = await client.GetAsync(TestRequest);
+
+			Assert.Equal(HttpStatusCode.Ambiguous, response.StatusCode);
+		}
+
+		/// <summary>
+		///		Verify that a <see cref="ClientBuilder{TContext}"/>, configured with a custom message pipeline terminus, can build an <see cref="HttpClient"/> with that message pipeline terminus.
+		/// </summary>
+		/// <returns>
+		///		A <see cref="Task"/> representing asynchronous test execution.
+		/// </returns>
+		[Fact]
+		public async Task BuilderWithCustomTerminus_Can_Build_Client()
+		{
+			using MockMessageHandler testHandler = TestHandlers.RespondWith(request =>
+			{
+				MessageAssert.HasRequestUri(request, TestRequestUri);
+
+				return request.CreateResponse(HttpStatusCode.Ambiguous);
+			});
+
+			ClientBuilder<TestBuilderContext> builder = new ClientBuilder<TestBuilderContext>()
+				.WithMessagePipelineTerminus(context =>
+				{
+					Assert.Same(_testBuilderContext, context);
+
+					return testHandler;
+				});
+
+			using HttpClient client = builder.CreateClient(_testBuilderContext, BaseUri);
+			using HttpResponseMessage response = await client.GetAsync(TestRequest);
+
+			Assert.Equal(HttpStatusCode.Ambiguous, response.StatusCode);
+		}
+
+		/// <summary>
+		///		Verify that a <see cref="ClientBuilder{TContext}"/>, configured with a custom message pipeline terminus, can build an <see cref="HttpClient"/> with a different message pipeline terminus.
+		/// </summary>
+		/// <returns>
+		///		A <see cref="Task"/> representing asynchronous test execution.
+		/// </returns>
+		[Fact]
+		public async Task BuilderWithCustomTerminus_Can_Build_Client_WithCustomTerminus()
+		{
+			using MockMessageHandler testHandler1 = TestHandlers.RespondWith(request =>
+			{
+				throw new AssertActualExpectedException(
+					expected: "testHandler2",
+					actual: "testHandler1",
+					userMessage: "Client was created with the wrong message pipeline terminus."
+				);
+			});
+			using MockMessageHandler testHandler2 = TestHandlers.RespondWith(request =>
+			{
+				MessageAssert.HasRequestUri(request, TestRequestUri);
+
+				return request.CreateResponse(HttpStatusCode.SeeOther);
+			});
+
+			ClientBuilder<TestBuilderContext> builder = new ClientBuilder<TestBuilderContext>()
+				.WithMessagePipelineTerminus(context =>
+				{
+					Assert.Same(_testBuilderContext, context);
+
+					return testHandler1;
+				});
+
+			using HttpClient client = builder.CreateClient(_testBuilderContext, BaseUri, messagePipelineTerminus: testHandler2);
+			using HttpResponseMessage response = await client.GetAsync(TestRequest);
+
+			Assert.Equal(HttpStatusCode.SeeOther, response.StatusCode);
+		}
+
+		/// <summary>
+		///		Dummy type to represent context for <see cref="ClientBuilder{TContext}"/>.
+		/// </summary>
+		class TestBuilderContext
+		{
+			/// <summary>
+			///		Create a new <see cref="TestBuilderContext"/>.
+			/// </summary>
+			public TestBuilderContext()
+			{
+			}
+		}
+	}
+}


### PR DESCRIPTION
Enable registration of named `HttpClient` (via `IHttpClientFactory`) using configuration from an HTTPlease `ClientBuilder` / `ClientBuilder<TContext>`.